### PR TITLE
Fix text domain and remove unused plugin check action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,9 +49,6 @@ jobs:
           rm -rf bin
         shell: bash
 
-      - name: Run wordpress plugin check
-        uses: wordpress/plugin-check-action@v1
-
       # Update Version
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/src/Integrations/Bricks/Elements/Archive_Block.php
+++ b/src/Integrations/Bricks/Elements/Archive_Block.php
@@ -79,14 +79,14 @@ class Archive_Block extends Element {
 		$this->controls['info'] = [
 			'tab'     => 'content',
 			'type'    => 'info',
-			'content' => esc_html__( 'This element will display the matching archive template content.', 'gutenbricks-archives' ),
+			'content' => esc_html__( 'This element will display the matching archive template content.', 'gutenbricks-archive' ),
 		];
 
 		$this->controls['fallbackContent'] = [
 			'tab'         => 'content',
-			'label'       => esc_html__( 'Fallback Content', 'gutenbricks-archives' ),
+			'label'       => esc_html__( 'Fallback Content', 'gutenbricks-archive' ),
 			'type'        => 'textarea',
-			'placeholder' => esc_html__( 'Content to show if no matching archive template is found', 'gutenbricks-archives' ),
+			'placeholder' => esc_html__( 'Content to show if no matching archive template is found', 'gutenbricks-archive' ),
 		];
 	}
 


### PR DESCRIPTION
Updated the text domain in `Archive_Block.php` for consistency with the plugin's namespace. Removed the `wordpress/plugin-check-action` step from the deploy workflow as it was unnecessary and redundant.